### PR TITLE
Fix pagination

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import "bulma/css/bulma";
 @import "@fortawesome/fontawesome-free/css/all.css";
 @import "politicians";
+@import "ranking";

--- a/app/assets/stylesheets/ranking.scss
+++ b/app/assets/stylesheets/ranking.scss
@@ -1,0 +1,3 @@
+.pagination {
+  padding: 10px;
+}

--- a/app/helpers/ranking_helper.rb
+++ b/app/helpers/ranking_helper.rb
@@ -1,0 +1,10 @@
+module RankingHelper
+  def get_ordinal_rating(page, index)
+    return get_order(page, index) - 25 unless page < 2
+    get_order(page, index)
+  end
+
+  def get_order(page, index)
+    (page * 25) + 1 + index
+  end
+end

--- a/app/views/politicians/ranking.html.erb
+++ b/app/views/politicians/ranking.html.erb
@@ -9,7 +9,7 @@
               <div class="box">
                 <article class="media">
                   <div class="media-left">
-                    <span class="tag is-success is-medium"><%= index + 1 %></span>
+                    <span class="tag is-success is-medium"><%= get_ordinal_rating(params['page'].to_i, index) %> </span>
                   </div>
                   <div class="media-right media-left">
                     <figure class="image is-128x128">


### PR DESCRIPTION
Foi corrigida a ordem de classificação dos políticos. Anteriormente todas as páginações exibiam a classificação de 1 a 25 em cada paginação. Agora na páginação 1 inicia com 1, na páginação 2 inicia com 26, na paginação 3 inicia com 51 e assim por diante.